### PR TITLE
Remove deprecated field

### DIFF
--- a/aks.tf
+++ b/aks.tf
@@ -6,7 +6,6 @@ resource "azurerm_kubernetes_cluster" "aks" {
   automatic_channel_upgrade     = "patch"
   public_network_access_enabled = true
   sku_tier                      = "Free"
-  enable_pod_security_policy    = false
   local_account_disabled        = false
   node_resource_group           = azurerm_resource_group.nodes.name
   oidc_issuer_enabled           = false


### PR DESCRIPTION
> The AKS API has removed support for this field on 2020-10-15 and is no longer possible to configure this the Pod Security Policy.